### PR TITLE
add millisecond precision to output logs

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -8,6 +8,11 @@
 
 #include "util.h"
 
+#ifdef __APPLE__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 static const char* util_log_get(log_t* l, const char* key)
 {
 	const char* value = log_get(l, key);
@@ -125,8 +130,20 @@ const char* util_get_time()
 #define TOTAL_TIME_LEN (MAX_STRFTIME_LEN + MILLIS_COMP_LEN + 1) // + null term
 	static char time_buf[TOTAL_TIME_LEN];
 	struct timespec tp;
+#ifdef __APPLE__
+	clock_serv_t cclock;
+	mach_timespec_t mts;
 
+
+	host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+	clock_get_time(cclock, &mts);
+	mach_port_deallocate(mach_task_self(), cclock);
+	tp.tv_sec = mts.tv_sec;
+	tp.tv_nsec = mts.tv_nsec;
+#else
 	clock_gettime(CLOCK_REALTIME, &tp);
+#endif
+
 	struct tm* local_time = localtime(&tp.tv_sec);
 
 #ifdef LOGD_DEBUG

--- a/src/util.c
+++ b/src/util.c
@@ -135,7 +135,7 @@ const char* util_get_time()
 	  strftime(time_buf, MAX_STRFTIME_LEN_TERM, "%X", local_time);
 	DEBUG_ASSERT(needs <= MAX_STRFTIME_LEN_TERM);
 
-	sprintf(time_buf + MAX_STRFTIME_LEN, ".%03d", tp.tv_nsec / 1000000);
+	sprintf(time_buf + MAX_STRFTIME_LEN, ".%03ld", tp.tv_nsec / 1000000);
 
 	return time_buf;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -119,17 +119,23 @@ const char* util_get_date()
 
 const char* util_get_time()
 {
-#define MAX_TIME_LEN 9 /* 8 + null terminator */
-	static char time_buf[MAX_TIME_LEN];
+#define MAX_STRFTIME_LEN 8
+#define MAX_STRFTIME_LEN_TERM 9
+#define MILLIS_COMP_LEN 4
+#define TOTAL_TIME_LEN (MAX_STRFTIME_LEN + MILLIS_COMP_LEN + 1) // + null term
+	static char time_buf[TOTAL_TIME_LEN];
+	struct timespec tp;
 
-	time_t raw_time = time(NULL);
-	struct tm* local_time = localtime(&raw_time);
+	clock_gettime(CLOCK_REALTIME, &tp);
+	struct tm* local_time = localtime(&tp.tv_sec);
 
 #ifdef LOGD_DEBUG
 	int needs =
 #endif
-	  strftime(time_buf, MAX_TIME_LEN, "%X", local_time);
-	DEBUG_ASSERT(needs + 1 <= MAX_TIME_LEN);
+	  strftime(time_buf, MAX_STRFTIME_LEN_TERM, "%X", local_time);
+	DEBUG_ASSERT(needs <= MAX_STRFTIME_LEN_TERM);
+
+	sprintf(time_buf + MAX_STRFTIME_LEN, ".%03d", tp.tv_nsec / 1000000);
 
 	return time_buf;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -133,7 +133,7 @@ const char* util_get_time()
 	int needs =
 #endif
 	  strftime(time_buf, MAX_STRFTIME_LEN_TERM, "%X", local_time);
-	DEBUG_ASSERT(needs <= MAX_STRFTIME_LEN_TERM);
+	DEBUG_ASSERT(needs <= MAX_STRFTIME_LEN);
 
 	sprintf(time_buf + MAX_STRFTIME_LEN, ".%03ld", tp.tv_nsec / 1000000);
 

--- a/test/fixture.lua
+++ b/test/fixture.lua
@@ -2,27 +2,27 @@ local logd = require('logd')
 local fixture = {}
 fixture.table_cases = {
 	{
-		output = "2018-05-12 12:52:28 DEBUG	[-]	-	it: works, ",
+		output = "2018-05-12 12:52:28.111 DEBUG	[-]	-	it: works, ",
 		input = {
 			it = "works",
 		},
 	},
 	{
-		output = "2018-05-12 12:52:28 DEBUG	[-]	-	letsee: it: works, ",
+		output = "2018-05-12 12:52:28.111 DEBUG	[-]	-	letsee: it: works, ",
 		input = {
 			it = "works",
 			callType = "letsee"
 		},
 	},
 	{
-		output = "2018-05-12 12:52:28 ERROR	[-]	-	a: b, ",
+		output = "2018-05-12 12:52:28.111 ERROR	[-]	-	a: b, ",
 		input = {
 			level = "ERROR",
 			a = "b"
 		},
 	},
 	{
-		output = "2018-05-12 12:52:28 INFO	[my  thread ]	hello	",
+		output = "2018-05-12 12:52:28.111 INFO	[my  thread ]	hello	",
 		input = {
 			level = "INFO",
 			thread = "my  thread ",
@@ -30,7 +30,7 @@ fixture.table_cases = {
 		},
 	},
 	{
-		output = "2018-05-12 12:52:28 DEBUG	[-]	-	userdata: <ptr>, tbl: <table>, fun: <func>, boolean: true, thr: <thread>, number: 45330342000000, ",
+		output = "2018-05-12 12:52:28.111 DEBUG	[-]	-	userdata: <ptr>, tbl: <table>, fun: <func>, boolean: true, thr: <thread>, number: 45330342000000, ",
 		input = {
 			number = 45330342000000,
 			boolean = true,
@@ -45,7 +45,7 @@ fixture.table_cases = {
 
 fixture.str_cases = {
 	{
-		output = "2018-05-12 12:52:28 DEBUG	[-]	-	msg: it: should not, sanitize: input, ",
+		output = "2018-05-12 12:52:28.111 DEBUG	[-]	-	msg: it: should not, sanitize: input, ",
 		input = "it: should not, sanitize: input",
 	}
 }

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -2,7 +2,7 @@ local lunit = require('lunit')
 local helper = {}
 
 helper.trim_ts = function(str)
-	local sample_ts = "2018-05-12 12:52:28"
+	local sample_ts = "2018-05-12 12:52:28.111"
 	return string.sub(str, string.len(sample_ts) + 2, string.len(str))
 end
 


### PR DESCRIPTION
# Description

Adds millisecond precision to logs created when using `logd.print` so instead of
```
2019-03-13 12:41:56	WARN	[-]	-	msg: blah 
```
we output something like
```
2019-03-13 12:41:56.007	WARN	[-]	-	msg: blah 
```

## Type of change
New feature (non-breaking change which adds functionality)