### PR TITLE
Adds prometheus example

### DIFF
--- a/examples/prometheus/.gitignore
+++ b/examples/prometheus/.gitignore
@@ -1,0 +1,2 @@
+deps
+data

--- a/examples/prometheus/main.lua
+++ b/examples/prometheus/main.lua
@@ -1,0 +1,49 @@
+--
+-- This example makes usage of luvit-prometheus module.
+-- Before running, make sure you install all the dependencies via `lit install`.
+--
+local logd = require("logd")
+local http = require('http')
+
+-- init prometheus module
+local prometheus = require('prometheus').init('logd_example_', {
+  log = function(level, msg)
+    logd.print({
+    	level = level,
+    	msg = "Prometheus error: " .. msg
+	})
+  end
+})
+
+-- init prometheus counter
+local metrics = prometheus:counter('logs', 'logs processed', {'status'})
+
+-- collect metrics and satisfy request
+local function on_metrics_request(req, res)
+  logd.print("reporting metrics to prometheus")
+
+  local body = prometheus:collect()
+  res:setHeader("Content-Type", "text/plain")
+  res:setHeader("Content-Length", #body)
+  res:finish(body)
+end
+
+local function setup_metrics_server(port)
+  if metrics == nil then
+  	  logd.print("Something went wrong when setting up Prometheus counter")
+  else
+      http.createServer(on_metrics_request):listen(port)
+      logd.print("Prometheus exporter listening at http://localhost:8080/")
+  end
+end
+
+-- example outgoing POST
+function logd.on_log(logptr)
+	metrics:inc(1, {'success'})
+end
+
+function logd.on_error(msg, logptr, at)
+	metrics:inc(1, {'failure'})
+end
+
+setup_metrics_server(8080)

--- a/examples/prometheus/package.lua
+++ b/examples/prometheus/package.lua
@@ -1,0 +1,9 @@
+return {
+	name = "logd/examples",
+	version = "0.0.1",
+	dependencies = {
+		"luvit/luvit@v2.14.2",
+		"creationix/pathjoin@v2.0.0",
+		"logctl/prometheus@v1.0.1",
+	}
+}

--- a/examples/prometheus/prometheus.yml
+++ b/examples/prometheus/prometheus.yml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval:     15s
+scrape_configs:
+  - job_name: 'my_logd'
+    static_configs:
+      - targets: ['localhost:8080']


### PR DESCRIPTION
# Description
Adds an example that uses logctl/luvit-prometheus example to export
metrics over HTTP that a Prometheus scraper is able to understand.